### PR TITLE
Feature/add example link

### DIFF
--- a/docs/schema/request/goIndex.json
+++ b/docs/schema/request/goIndex.json
@@ -2,6 +2,9 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "goIndex.json",
   "type": "object",
+  "examples": [
+    {"$ref": "example/goIndex.json"}
+  ],
   "properties": {
   }
 }

--- a/docs/schema/response/AlpsItemEdit.json
+++ b/docs/schema/response/AlpsItemEdit.json
@@ -3,9 +3,7 @@
   "$id": "AlpsItemEdit.json",
   "type": "object",
   "examples": [
-    {
-      "$ref": "example/AlpsItemEdit.json"
-    }
+    {"$ref": "example/AlpsItemEdit.json"}
   ],
   "properties": {
     "alpsItem": {


### PR DESCRIPTION
- https://github.com/ma-alps/spec/commit/cb9f84a02241710198805b86e08c1754a21ead70
  - [exmaple/goIndex.json](https://github.com/ma-alps/spec/blob/master/docs/schema/request/example/goIndex.json)の中身は空に近いが、他のschemaと揃える意味ではあったほうがいいと思い追加しときました。
- https://github.com/ma-alps/spec/commit/7ed0f42d39c49955845886ed95e1c7bcb4229917
  - 1行で表せてなかったので直しました。